### PR TITLE
KLO-103 :  Needs to Implement Skeletons for multiple screens

### DIFF
--- a/fake-data-generator/gen.ts
+++ b/fake-data-generator/gen.ts
@@ -22,6 +22,10 @@ const types: string[] = [
   'ConsoleListManagedResourceQuery',
   'ConsoleListHelmChartQuery',
   'ConsoleListConsoleVpnDevices',
+  'ConsoleListProjectMSvsQuery',
+  'ConsoleListMSvTemplatesQuery',
+  'ConsoleListRoutersQuery',
+  'ConsoleListManagedResourcesQuery'
 ];
 
 async function fake(files: string[], types: string[] = []) {

--- a/src/apps/console/routes/_main+/$account+/$project+/$environment+/managed-resources/route.tsx
+++ b/src/apps/console/routes/_main+/$account+/$project+/$environment+/managed-resources/route.tsx
@@ -9,6 +9,7 @@ import { parseNodes } from '~/console/server/r-utils/common';
 import { IRemixCtx } from '~/root/lib/types/common';
 import Tools from './tools';
 import ManagedResourceResources from './managed-resources-resource';
+import fake from "~/root/fake-data-generator/fake";
 
 export const loader = (ctx: IRemixCtx) => {
   const { project, environment } = ctx.params;
@@ -32,7 +33,12 @@ const KlOperatorServices = () => {
   const { promise } = useLoaderData<typeof loader>();
 
   return (
-    <LoadingComp data={promise}>
+    <LoadingComp
+        data={promise}
+        skeletonData={{
+          managedResourcesData: fake.ConsoleListManagedResourcesQuery.core_listManagedResources as any,
+        }}
+    >
       {({ managedResourcesData }) => {
         const managedResources = parseNodes(managedResourcesData);
 

--- a/src/apps/console/routes/_main+/$account+/$project+/$environment+/routers/_index.tsx
+++ b/src/apps/console/routes/_main+/$account+/$project+/$environment+/routers/_index.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react';
 import Tools from './tools';
 import HandleRouter from './handle-router';
 import RouterResources from './router-resources';
+import fake from "~/root/fake-data-generator/fake";
 
 export const loader = async (ctx: IRemixCtx) => {
   ensureAccountSet(ctx);
@@ -44,7 +45,12 @@ const Routers = () => {
 
   return (
     <>
-      <LoadingComp data={promise}>
+      <LoadingComp
+          data={promise}
+          skeletonData={{
+            routersData: fake.ConsoleListRoutersQuery.core_listRouters as any,
+          }}
+      >
         {({ routersData }) => {
           const routers = parseNodes(routersData);
           if (!routers) {

--- a/src/apps/console/routes/_main+/$account+/$project+/managed-services/route.tsx
+++ b/src/apps/console/routes/_main+/$account+/$project+/managed-services/route.tsx
@@ -9,6 +9,7 @@ import { parseNodes } from '~/console/server/r-utils/common';
 import { IRemixCtx } from '~/root/lib/types/common';
 import Tools from './tools';
 import BackendServicesResources from './backend-services-resources';
+import fake from "~/root/fake-data-generator/fake";
 
 export const loader = (ctx: IRemixCtx) => {
   const { project } = ctx.params;
@@ -40,7 +41,13 @@ const KlOperatorServices = () => {
   const { promise } = useLoaderData<typeof loader>();
 
   return (
-    <LoadingComp data={promise}>
+    <LoadingComp
+        data={promise}
+        skeletonData={{
+          managedServices: fake.ConsoleListProjectMSvsQuery.core_listProjectManagedServices as any,
+          templates: fake.ConsoleListMSvTemplatesQuery.infra_listManagedServiceTemplates as any
+        }}
+    >
       {({ managedServices, templates: templatesData }) => {
         const backendServices = parseNodes(managedServices);
 

--- a/src/apps/console/routes/_main+/$account+/infra+/$cluster+/helm-charts/_index.tsx
+++ b/src/apps/console/routes/_main+/$account+/infra+/$cluster+/helm-charts/_index.tsx
@@ -11,6 +11,7 @@ import { IRemixCtx } from '~/root/lib/types/common';
 import Tools from './tools';
 import HelmChartResources from './helm-chart-resources';
 import HandleHelmChart from './handle-helm-chart';
+import fake from "~/root/fake-data-generator/fake";
 
 export const loader = (ctx: IRemixCtx) => {
   const { cluster } = ctx.params;
@@ -36,7 +37,12 @@ const HelmCharts = () => {
 
   return (
     <>
-      <LoadingComp data={promise}>
+      <LoadingComp
+          data={promise}
+          skeletonData={{
+            helmChartData: fake.ConsoleListHelmChartQuery.infra_listHelmReleases as any,
+          }}
+      >
         {({ helmChartData }) => {
           const helmCharts = parseNodes(helmChartData);
 

--- a/src/apps/console/routes/_main+/$account+/infra+/$cluster+/nodepools/route.tsx
+++ b/src/apps/console/routes/_main+/$account+/infra+/$cluster+/nodepools/route.tsx
@@ -15,6 +15,7 @@ import { getPagination, getSearch } from '~/console/server/utils/common';
 import HandleNodePool from './handle-nodepool';
 import Tools from './tools';
 import NodepoolResources from './nodepool-resources';
+import fake from "~/root/fake-data-generator/fake";
 
 export const loader = async (ctx: IRemixCtx) => {
   ensureAccountSet(ctx);
@@ -47,10 +48,9 @@ const Nodepools = () => {
     <>
       <LoadingComp
         data={promise}
-        // skeletonData={{
-        //   nodePoolData: fake.ConsoleListNodePoolsQuery
-        //     .infra_listNodePools as any,
-        // }}
+        skeletonData={{
+          nodePoolData: fake.ConsoleListNodePoolsQuery.infra_listNodePools as any,
+        }}
       >
         {({ nodePoolData }) => {
           const nodepools = nodePoolData?.edges?.map(({ node }) => node);

--- a/src/generated/gql/sdl.graphql
+++ b/src/generated/gql/sdl.graphql
@@ -3223,6 +3223,7 @@ scalar ProviderDetail
 
 type Query {
   accounts_checkNameAvailability(name: String!): AccountsCheckNameAvailabilityOutput!
+  accounts_ensureKloudliteRegistryPullSecrets(accountName: String!): Boolean!
   accounts_getAccount(accountName: String!): Account
   accounts_getAccountMembership(accountName: String!): AccountMembership
   accounts_getInvitation(accountName: String!, invitationId: String!): Invitation


### PR DESCRIPTION
Resolves kloudlite/kloudlite#48

implements skeltons for below screens:
- project managed services
- managed resource
- routers
- nodepool
- helmcharts

# Attachment

<img width="1470" alt="Screenshot 2024-02-28 at 5 38 28 PM" src="https://github.com/kloudlite/web/assets/52462496/e47ab644-a0cf-4b35-b1b5-b1d77e785827">

<img width="1470" alt="Screenshot 2024-02-28 at 5 51 19 PM" src="https://github.com/kloudlite/web/assets/52462496/9a4f50d7-dfb5-4ee0-ac31-30235d5ea58c">

<img width="1470" alt="Screenshot 2024-02-28 at 5 53 51 PM" src="https://github.com/kloudlite/web/assets/52462496/7829ff63-fc17-4920-a0f3-5f46e1d3dd64">

<img width="1470" alt="Screenshot 2024-02-28 at 5 56 17 PM" src="https://github.com/kloudlite/web/assets/52462496/f14a825b-7c5a-4d4d-aab6-3f9adcae1893">

<img width="1470" alt="Screenshot 2024-02-28 at 5 59 33 PM" src="https://github.com/kloudlite/web/assets/52462496/0dd6ac67-c75d-48d5-9beb-451857d1c467">
 