### PR TITLE
KLO-230 : Namespaces are not getting listed when installing helm chart

### DIFF
--- a/src/apps/console/routes/_a+/new-team.tsx
+++ b/src/apps/console/routes/_a+/new-team.tsx
@@ -17,11 +17,17 @@ import { SignOut } from '@jengaicons/react';
 import { authBaseUrl } from '~/root/lib/configs/base-url.cjs';
 import { useExternalRedirect } from '~/root/lib/client/helpers/use-redirect';
 import { Button } from '~/components/atoms/button';
+import useCustomSwr from '~/root/lib/client/hooks/use-custom-swr';
 
 const NewAccount = () => {
   const api = useConsoleApi();
   const navigate = useNavigate();
   const user = useDataFromMatches<UserMe>('user', {});
+
+  const { data: accountsData } = useCustomSwr('/list_accounts', async () => {
+    return api.listAccounts({});
+  });
+
   const { values, handleChange, errors, isLoading, handleSubmit } = useForm({
     initialValues: {
       name: '',
@@ -64,15 +70,17 @@ const NewAccount = () => {
         fillerImage={<FillerCreateTeam />}
         title="Setup your account!"
         action={
-          <Button
-            variant="plain"
-            suffix={<SignOut />}
-            size="sm"
-            content="Sign Out"
-            onClick={() => {
-              eNavigate(`${authBaseUrl}/logout`);
-            }}
-          />
+          accountsData?.length === 0 && (
+            <Button
+              variant="plain"
+              suffix={<SignOut />}
+              size="sm"
+              content="Sign Out"
+              onClick={() => {
+                eNavigate(`${authBaseUrl}/logout`);
+              }}
+            />
+          )
         }
         subTitle="Simplify Collaboration and Enhance Productivity with Kloudlite
   teams"

--- a/src/apps/console/server/gql/queries/namespace-queries.ts
+++ b/src/apps/console/server/gql/queries/namespace-queries.ts
@@ -49,24 +49,6 @@ export const namespaceQueries = (executor: IExecutor) => ({
               spec {
                 finalizers
               }
-              status {
-                conditions {
-                  lastTransitionTime
-                  message
-                  reason
-                  status
-                  type
-                }
-                phase
-              }
-              syncStatus {
-                action
-                error
-                lastSyncedAt
-                recordVersion
-                state
-                syncScheduledAt
-              }
               updateTime
             }
           }
@@ -83,7 +65,7 @@ export const namespaceQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleListNamespacesQuery) =>
         data.infra_listNamespaces,
-      vars(_: ConsoleListNamespacesQueryVariables) { },
+      vars(_: ConsoleListNamespacesQueryVariables) {},
     }
   ),
 });


### PR DESCRIPTION
Resolves kloudlite/kloudlite#62

- namespace list in showing
- signout button in new account will only show when there will be no account

# Attachment
<img width="928" alt="Screenshot 2024-03-19 at 4 44 38 PM" src="https://github.com/kloudlite/web/assets/52462496/10b6158d-2655-4671-85e9-674779b4073c">

