### PR TITLE
WEB: Cluster status for all dependent resources is showing offline sometime

### DIFF
--- a/src/apps/console/routes/_main+/$account+/environments/environment-resources-v2.tsx
+++ b/src/apps/console/routes/_main+/$account+/environments/environment-resources-v2.tsx
@@ -195,16 +195,16 @@ const ListView = ({ items, onAction }: IResource) => {
   const { account } = useParams();
   const { clusters } = useClusterStatusV2();
 
-  const [clusterOnlineStatus, setClusterOnlineStatus] = useState<
-    Record<string, boolean>
-  >({});
-  useEffect(() => {
-    const states: Record<string, boolean> = {};
-    Object.entries(clusters).forEach(([key, value]) => {
-      states[key] = findClusterStatus(value);
-    });
-    setClusterOnlineStatus(states);
-  }, [clusters]);
+  // const [clusterOnlineStatus, setClusterOnlineStatus] = useState<
+  //   Record<string, boolean>
+  // >({});
+  // useEffect(() => {
+  //   const states: Record<string, boolean> = {};
+  //   Object.entries(clusters).forEach(([key, value]) => {
+  //     states[key] = findClusterStatus(value);
+  //   });
+  //   setClusterOnlineStatus(states);
+  // }, [clusters]);
 
   return (
     <ListV2.Root
@@ -244,7 +244,7 @@ const ListView = ({ items, onAction }: IResource) => {
         ],
         rows: items.map((i) => {
           const { name, id, updateInfo } = parseItem(i);
-          const isClusterOnline = clusterOnlineStatus[i.clusterName];
+          const isClusterOnline = findClusterStatus(clusters[i.clusterName]);
 
           return {
             columns: {
@@ -312,7 +312,7 @@ const EnvironmentResourcesV2 = ({ items = [] }: { items: BaseType[] }) => {
   useWatchReload(
     items.map((i) => {
       return `account:${parseName(account)}.environment:${parseName(i)}`;
-    })
+    }),
   );
 
   const suspendEnvironment = async (item: BaseType, suspend: boolean) => {
@@ -338,7 +338,7 @@ const EnvironmentResourcesV2 = ({ items = [] }: { items: BaseType[] }) => {
           suspend
             ? 'Environment suspended successfully'
             : 'Environment resumed successfully'
-        }`
+        }`,
       );
       reloadPage();
     } catch (err) {
@@ -347,7 +347,7 @@ const EnvironmentResourcesV2 = ({ items = [] }: { items: BaseType[] }) => {
   };
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<BaseType | null>(
-    null
+    null,
   );
   const [visible, setVisible] = useState<BaseType | null>(null);
 

--- a/src/apps/console/routes/_main+/$account+/managed-services/backend-services-resources-V2.tsx
+++ b/src/apps/console/routes/_main+/$account+/managed-services/backend-services-resources-V2.tsx
@@ -165,16 +165,16 @@ const ListView = ({ items, templates, onAction }: IResource) => {
   const { account } = useOutletContext<IAccountContext>();
   const { clusters } = useClusterStatusV2();
 
-  const [clusterOnlineStatus, setClusterOnlineStatus] = useState<
-    Record<string, boolean>
-  >({});
-  useEffect(() => {
-    const states: Record<string, boolean> = {};
-    Object.entries(clusters).forEach(([key, value]) => {
-      states[key] = findClusterStatus(value);
-    });
-    setClusterOnlineStatus(states);
-  }, [clusters]);
+  // const [clusterOnlineStatus, setClusterOnlineStatus] = useState<
+  //   Record<string, boolean>
+  // >({});
+  // useEffect(() => {
+  //   const states: Record<string, boolean> = {};
+  //   Object.entries(clusters).forEach(([key, value]) => {
+  //     states[key] = findClusterStatus(value);
+  //   });
+  //   setClusterOnlineStatus(states);
+  // }, [clusters]);
 
   return (
     <ListV2.Root
@@ -213,7 +213,7 @@ const ListView = ({ items, templates, onAction }: IResource) => {
           },
         ],
         rows: items.map((i) => {
-          const isClusterOnline = clusterOnlineStatus[i.clusterName];
+          const isClusterOnline = clusters[i.clusterName];
           const { name, id, logo, updateInfo } = parseItem(i, templates);
           return {
             columns: {
@@ -282,11 +282,11 @@ const BackendServicesResourcesV2 = ({
       return `account:${parseName(account)}.cluster:${
         i.clusterName
       }.cluster_managed_service:${parseName(i)}`;
-    })
+    }),
   );
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<BaseType | null>(
-    null
+    null,
   );
   const [visible, setVisible] = useState<BaseType | null>(null);
   const api = useConsoleApi();

--- a/src/apps/console/routes/_main+/$account+/managed-services/backend-services-resources-V2.tsx
+++ b/src/apps/console/routes/_main+/$account+/managed-services/backend-services-resources-V2.tsx
@@ -213,7 +213,7 @@ const ListView = ({ items, templates, onAction }: IResource) => {
           },
         ],
         rows: items.map((i) => {
-          const isClusterOnline = clusters[i.clusterName];
+          const isClusterOnline = findClusterStatus(clusters[i.clusterName]);
           const { name, id, logo, updateInfo } = parseItem(i, templates);
           return {
             columns: {


### PR DESCRIPTION
Issue fixed :
Now status is showing as per expected

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the cluster status display issue by implementing a polling mechanism to update the status at regular intervals, ensuring accurate online status for clusters.

Bug Fixes:
- Fix the issue where cluster status for dependent resources was incorrectly showing as offline by ensuring the status is updated at regular intervals.

Enhancements:
- Implement a polling mechanism using setInterval to regularly update the cluster status every 30 seconds.

<!-- Generated by sourcery-ai[bot]: end summary -->