### PR TITLE
cli query update for creating cluster

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -6421,6 +6421,7 @@ query authCli_getRemoteLogin($loginId: String!, $secret: String!) {
 mutation authCli_createClusterReference($cluster: BYOKClusterIn!) {
   infra_createBYOKCluster(cluster: $cluster) {
     id
+    clusterToken
     metadata {
       name
     }

--- a/src/apps/auth/server/gql/cli-queries.ts
+++ b/src/apps/auth/server/gql/cli-queries.ts
@@ -722,6 +722,7 @@ export const cliQueries = (executor: IExecutor) => ({
       mutation Infra_createBYOKCluster($cluster: BYOKClusterIn!) {
         infra_createBYOKCluster(cluster: $cluster) {
           id
+          clusterToken
           metadata {
             name
           }

--- a/src/generated/gql/sdl.graphql
+++ b/src/generated/gql/sdl.graphql
@@ -65,6 +65,7 @@ type App {
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata
+  onlineStatus: OnlineStatus
   recordVersion: Int!
   serviceHost: String
   spec: Github__com___kloudlite___operator___apis___crds___v1__AppSpec!
@@ -425,6 +426,7 @@ enum ConsoleResType {
   imported_managed_resource
   managed_resource
   managed_service
+  registry_image
   router
   secret
   vpn_device
@@ -577,6 +579,7 @@ type Environment {
   lastUpdatedBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
   markedForDeletion: Boolean
   metadata: Metadata
+  onlineStatus: OnlineStatus
   recordVersion: Int!
   spec: Github__com___kloudlite___operator___apis___crds___v1__EnvironmentSpec
   status: Github__com___kloudlite___operator___pkg___operator__Status
@@ -2214,6 +2217,7 @@ type ImportedManagedResource {
   managedResourceRef: Github__com___kloudlite___api___apps___console___internal___entities__ManagedResourceRef!
   markedForDeletion: Boolean
   name: String!
+  onlineStatus: OnlineStatus
   recordVersion: Int!
   secretRef: Github__com___kloudlite___operator___apis___common____types__SecretRef!
   syncStatus: Github__com___kloudlite___api___pkg___types__SyncStatus!
@@ -3580,6 +3584,7 @@ type Mutation {
   core_deleteImagePullSecret(name: String!): Boolean!
   core_deleteImportedManagedResource(envName: String!, importName: String!): Boolean!
   core_deleteManagedResource(mresName: String!, msvcName: String!): Boolean!
+  core_deleteRegistryImage(image: String!): Boolean!
   core_deleteRouter(envName: String!, routerName: String!): Boolean!
   core_deleteSecret(envName: String!, secretName: String!): Boolean!
   core_importManagedResource(envName: String!, importName: String!, mresName: String!, msvcName: String!): ImportedManagedResource
@@ -3813,6 +3818,11 @@ type OAuthProviderStatus {
   provider: String!
 }
 
+type OnlineStatus {
+  lastOnlineAt: Date!
+  willBeOfflineAt: Date!
+}
+
 type PageInfo {
   endCursor: String
   hasNextPage: Boolean
@@ -3940,6 +3950,8 @@ type Query {
   core_getManagedResouceOutputKeys(envName: String, msvcName: String, name: String!): [String!]!
   core_getManagedResouceOutputKeyValues(envName: String, keyrefs: [ManagedResourceKeyRefIn], msvcName: String): [ManagedResourceKeyValueRef!]!
   core_getManagedResource(envName: String, msvcName: String, name: String!): ManagedResource
+  core_getRegistryImage(image: String!): RegistryImage
+  core_getRegistryImageURL(image: String!, meta: Map!): RegistryImageURL!
   core_getRouter(envName: String!, name: String!): Router
   core_getSecret(envName: String!, name: String!): Secret
   core_getSecretValues(envName: String!, queries: [SecretKeyRefIn!]): [SecretKeyValueRef!]
@@ -3950,6 +3962,7 @@ type Query {
   core_listImagePullSecrets(pq: CursorPaginationIn, search: SearchImagePullSecrets): ImagePullSecretPaginatedRecords
   core_listImportedManagedResources(envName: String!, pq: CursorPaginationIn, search: SearchImportedManagedResources): ImportedManagedResourcePaginatedRecords
   core_listManagedResources(pq: CursorPaginationIn, search: SearchManagedResources): ManagedResourcePaginatedRecords
+  core_listRegistryImages(pq: CursorPaginationIn): RegistryImagePaginatedRecords
   core_listRouters(envName: String!, pq: CursorPaginationIn, search: SearchRouters): RouterPaginatedRecords
   core_listSecrets(envName: String!, pq: CursorPaginationIn, search: SearchSecrets): SecretPaginatedRecords
   core_restartApp(appName: String!, envName: String!): Boolean!
@@ -4019,6 +4032,73 @@ type Query {
   iot_listDevices(deploymentName: String!, pq: CursorPaginationIn, projectName: String!, search: SearchIOTDevices): IOTDevicePaginatedRecords
   iot_listProjects(pq: CursorPaginationIn, search: SearchIOTProjects): IOTProjectPaginatedRecords
   oAuth_requestLogin(provider: String!, state: String): URL!
+}
+
+type RegistryImage {
+  accountName: String!
+  creationTime: Date!
+  id: ID!
+  imageName: String!
+  imageTag: String!
+  markedForDeletion: Boolean
+  meta: Map!
+  recordVersion: Int!
+  updateTime: Date!
+}
+
+type RegistryImageCredentials {
+  accountName: String!
+  createdBy: Github__com___kloudlite___api___common__CreatedOrUpdatedBy!
+  creationTime: Date!
+  id: ID!
+  markedForDeletion: Boolean
+  password: String!
+  recordVersion: Int!
+  updateTime: Date!
+}
+
+type RegistryImageCredentialsEdge {
+  cursor: String!
+  node: RegistryImageCredentials!
+}
+
+input RegistryImageCredentialsIn {
+  accountName: String!
+  password: String!
+}
+
+type RegistryImageCredentialsPaginatedRecords {
+  edges: [RegistryImageCredentialsEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type RegistryImageEdge {
+  cursor: String!
+  node: RegistryImage!
+}
+
+input RegistryImageIn {
+  accountName: String!
+  imageName: String!
+  imageTag: String!
+  meta: Map!
+}
+
+type RegistryImagePaginatedRecords {
+  edges: [RegistryImageEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type RegistryImageURL {
+  scriptUrl: String!
+  url: String!
+}
+
+input RegistryImageURLIn {
+  scriptUrl: String!
+  url: String!
 }
 
 type RemoteLogin {
@@ -4252,6 +4332,10 @@ input SearchProjects {
 
 input SearchProviderSecret {
   cloudProviderName: MatchFilterIn
+  text: MatchFilterIn
+}
+
+input SearchRegistryImages {
   text: MatchFilterIn
 }
 

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -62,6 +62,7 @@ export type ConsoleResType =
   | 'imported_managed_resource'
   | 'managed_resource'
   | 'managed_service'
+  | 'registry_image'
   | 'router'
   | 'secret'
   | 'vpn_device';
@@ -1754,6 +1755,23 @@ export type PortIn = {
   targetPort?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type RegistryImageCredentialsIn = {
+  accountName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+};
+
+export type RegistryImageIn = {
+  accountName: Scalars['String']['input'];
+  imageName: Scalars['String']['input'];
+  imageTag: Scalars['String']['input'];
+  meta: Scalars['Map']['input'];
+};
+
+export type RegistryImageUrlIn = {
+  scriptUrl: Scalars['String']['input'];
+  url: Scalars['String']['input'];
+};
+
 export type SearchProjectManagedService = {
   isReady?: InputMaybe<MatchFilterIn>;
   managedServiceName?: InputMaybe<MatchFilterIn>;
@@ -1764,6 +1782,10 @@ export type SearchProjectManagedService = {
 export type SearchProjects = {
   isReady?: InputMaybe<MatchFilterIn>;
   markedForDeletion?: InputMaybe<MatchFilterIn>;
+  text?: InputMaybe<MatchFilterIn>;
+};
+
+export type SearchRegistryImages = {
   text?: InputMaybe<MatchFilterIn>;
 };
 
@@ -8041,7 +8063,11 @@ export type AuthCli_CreateClusterReferenceMutationVariables = Exact<{
 }>;
 
 export type AuthCli_CreateClusterReferenceMutation = {
-  infra_createBYOKCluster?: { id: string; metadata: { name: string } };
+  infra_createBYOKCluster?: {
+    id: string;
+    clusterToken: string;
+    metadata: { name: string };
+  };
 };
 
 export type AuthCli_DeleteClusterReferenceMutationVariables = Exact<{


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the GraphQL schema by adding new types and queries for managing registry images and tracking online status. Update the cluster creation mutation to include a cluster token in the response.

New Features:
- Introduce a new type 'OnlineStatus' to track the online status of various entities, including 'App', 'Environment', and 'ImportedManagedResource'.
- Add new GraphQL types and inputs related to 'RegistryImage', including 'RegistryImage', 'RegistryImageCredentials', 'RegistryImageURL', and their respective paginated records and input types.
- Add new GraphQL queries and mutations for managing registry images, such as 'core_getRegistryImage', 'core_getRegistryImageURL', 'core_listRegistryImages', and 'core_deleteRegistryImage'.

Enhancements:
- Update the 'AuthCli_CreateClusterReferenceMutation' to include a 'clusterToken' in the response, enhancing the cluster creation process.

<!-- Generated by sourcery-ai[bot]: end summary -->