### PR TITLE
cluster status issue fix

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -394,6 +394,19 @@ query consoleGetCluster($name: String!) {
   }
 }
 
+query consoleListClusterStatus($pagination: CursorPaginationIn) {
+  infra_listBYOKClusters(pagination: $pagination) {
+    edges {
+      node {
+        lastOnlineAt
+        metadata {
+          name
+        }
+      }
+    }
+  }
+}
+
 query consoleGetKubeConfig($name: String!) {
   infra_getCluster(name: $name) {
     adminKubeconfig {

--- a/src/apps/console/hooks/use-cluster-status-v2.tsx
+++ b/src/apps/console/hooks/use-cluster-status-v2.tsx
@@ -36,17 +36,17 @@ const ClusterStatusProvider = ({ children }: { children: ReactNode }) => {
 
   const listCluster = useCallback(async () => {
     try {
-      const cl = await api.listClusterStatus({
+      const { data } = await api.listClusterStatus({
         pagination: {
           first: 500,
         },
       });
-      const parsed = parseNodes(cl.data).reduce((acc, c) => {
+      const parsed = parseNodes(data).reduce((acc, c) => {
         acc[c.metadata.name] = c;
         return acc;
       }, {} as IClusterMap);
       setClusters(parsed);
-      return clusters;
+      return parsed;
     } catch (err) {
       console.error(err);
       return false;

--- a/src/apps/console/hooks/use-cluster-status-v2.tsx
+++ b/src/apps/console/hooks/use-cluster-status-v2.tsx
@@ -13,10 +13,10 @@ import {
 import { useSocketWatch } from '~/root/lib/client/helpers/socket/useWatch';
 import useDebounce from '~/root/lib/client/hooks/use-debounce';
 import { useConsoleApi } from '../server/gql/api-provider';
-import { IByocClusters } from '../server/gql/queries/byok-cluster-queries';
 import { ExtractNodeType, parseNodes } from '../server/r-utils/common';
+import { IClustersStatus } from '../server/gql/queries/cluster-queries';
 
-type IClusterMap = { [key: string]: ExtractNodeType<IByocClusters> };
+type IClusterMap = { [key: string]: ExtractNodeType<IClustersStatus> };
 
 const ClusterStatusContext = createContext<{
   clusters: IClusterMap;
@@ -36,14 +36,15 @@ const ClusterStatusProvider = ({ children }: { children: ReactNode }) => {
 
   const listCluster = useCallback(async () => {
     try {
-      const cl = await api.listAllClusters();
-      const parsed = parseNodes(cl.data).reduce(
-        (acc, c) => {
-          acc[c.metadata.name] = c;
-          return acc;
+      const cl = await api.listClusterStatus({
+        pagination: {
+          first: 5,
         },
-        {} as { [key: string]: ExtractNodeType<IByocClusters> },
-      );
+      });
+      const parsed = parseNodes(cl.data).reduce((acc, c) => {
+        acc[c.metadata.name] = c;
+        return acc;
+      }, {} as IClusterMap);
       setClusters(parsed);
       return clusters;
     } catch (err) {
@@ -56,8 +57,18 @@ const ClusterStatusProvider = ({ children }: { children: ReactNode }) => {
     const interval = setInterval(() => {
       listCluster();
     }, 30 * 1000);
+
+    const onlineEvent = () => {
+      setTimeout(() => {
+        listCluster();
+      }, 3000);
+    };
+
+    window.addEventListener('online', onlineEvent);
+
     return () => {
       clearInterval(interval);
+      window.removeEventListener('online', onlineEvent);
     };
   }, []);
 
@@ -72,10 +83,6 @@ const ClusterStatusProvider = ({ children }: { children: ReactNode }) => {
   useSocketWatch(() => {
     setUpdate((p) => !p);
   }, topic);
-
-  useEffect(() => {
-    console.log('helre', topic);
-  }, [topic]);
 
   return (
     <ClusterStatusContext.Provider

--- a/src/apps/console/hooks/use-cluster-status-v2.tsx
+++ b/src/apps/console/hooks/use-cluster-status-v2.tsx
@@ -38,7 +38,7 @@ const ClusterStatusProvider = ({ children }: { children: ReactNode }) => {
     try {
       const cl = await api.listClusterStatus({
         pagination: {
-          first: 5,
+          first: 500,
         },
       });
       const parsed = parseNodes(cl.data).reduce((acc, c) => {

--- a/src/apps/console/server/gql/queries/cluster-queries.ts
+++ b/src/apps/console/server/gql/queries/cluster-queries.ts
@@ -19,10 +19,15 @@ import {
   ConsoleListDnsHostsQueryVariables,
   ConsoleListAllClustersQuery,
   ConsoleListAllClustersQueryVariables,
+  ConsoleListClusterStatusQuery,
+  ConsoleListClusterStatusQueryVariables,
 } from '~/root/src/generated/gql/server';
 
 export type ICluster = NN<ConsoleGetClusterQuery['infra_getCluster']>;
 export type IClusters = NN<ConsoleListClustersQuery['infra_listClusters']>;
+export type IClustersStatus = NN<
+  ConsoleListClusterStatusQuery['infra_listClusters']
+>;
 
 export type IDnsHosts = NN<ConsoleListDnsHostsQuery>['infra_listClusters'];
 
@@ -50,7 +55,7 @@ export const clusterQueries = (executor: IExecutor) => ({
         return data.infra_listClusters;
       },
       vars(_: ConsoleListDnsHostsQueryVariables) {},
-    }
+    },
   ),
 
   createCluster: executor(
@@ -65,7 +70,7 @@ export const clusterQueries = (executor: IExecutor) => ({
       transformer: (data: ConsoleCreateClusterMutation) =>
         data.infra_createCluster,
       vars(_: ConsoleCreateClusterMutationVariables) {},
-    }
+    },
   ),
   deleteCluster: executor(
     gql`
@@ -77,7 +82,7 @@ export const clusterQueries = (executor: IExecutor) => ({
       transformer: (data: ConsoleDeleteClusterMutation) =>
         data.infra_deleteCluster,
       vars(_: ConsoleDeleteClusterMutationVariables) {},
-    }
+    },
   ),
   clustersCount: executor(
     gql`
@@ -90,7 +95,7 @@ export const clusterQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleClustersCountQuery) => data.infra_listClusters,
       vars(_: ConsoleClustersCountQueryVariables) {},
-    }
+    },
   ),
 
   listAllClusters: executor(
@@ -271,9 +276,8 @@ export const clusterQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleListAllClustersQuery) => data.byok_clusters,
       vars(_: ConsoleListAllClustersQueryVariables) {},
-    }
+    },
   ),
-
   listClusters: executor(
     gql`
       query Infra_listClusterss(
@@ -396,7 +400,7 @@ export const clusterQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleListClustersQuery) => data.infra_listClusters,
       vars(_: ConsoleListClustersQueryVariables) {},
-    }
+    },
   ),
   getCluster: executor(
     gql`
@@ -502,7 +506,28 @@ export const clusterQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleGetClusterQuery) => data.infra_getCluster,
       vars(_: ConsoleGetClusterQueryVariables) {},
-    }
+    },
+  ),
+  listClusterStatus: executor(
+    gql`
+      query listCluster($pagination: CursorPaginationIn) {
+        infra_listBYOKClusters(pagination: $pagination) {
+          edges {
+            node {
+              lastOnlineAt
+              metadata {
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      transformer: (data: ConsoleListClusterStatusQuery) =>
+        data.infra_listBYOKClusters,
+      vars(_: ConsoleListClusterStatusQueryVariables) {},
+    },
   ),
   getKubeConfig: executor(
     gql`
@@ -518,7 +543,7 @@ export const clusterQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleGetKubeConfigQuery) => data.infra_getCluster,
       vars(_: ConsoleGetClusterQueryVariables) {},
-    }
+    },
   ),
   updateCluster: executor(
     gql`
@@ -532,6 +557,6 @@ export const clusterQueries = (executor: IExecutor) => ({
       transformer: (data: ConsoleUpdateClusterMutation) =>
         data.infra_updateCluster,
       vars(_: ConsoleUpdateClusterMutationVariables) {},
-    }
+    },
   ),
 });

--- a/src/apps/console/server/gql/queries/cluster-queries.ts
+++ b/src/apps/console/server/gql/queries/cluster-queries.ts
@@ -26,7 +26,7 @@ import {
 export type ICluster = NN<ConsoleGetClusterQuery['infra_getCluster']>;
 export type IClusters = NN<ConsoleListClustersQuery['infra_listClusters']>;
 export type IClustersStatus = NN<
-  ConsoleListClusterStatusQuery['infra_listClusters']
+  ConsoleListClusterStatusQuery['infra_listBYOKClusters']
 >;
 
 export type IDnsHosts = NN<ConsoleListDnsHostsQuery>['infra_listClusters'];

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -2192,6 +2192,16 @@ export type ConsoleGetClusterQuery = {
   };
 };
 
+export type ConsoleListClusterStatusQueryVariables = Exact<{
+  pagination?: InputMaybe<CursorPaginationIn>;
+}>;
+
+export type ConsoleListClusterStatusQuery = {
+  infra_listBYOKClusters?: {
+    edges: Array<{ node: { lastOnlineAt?: any; metadata: { name: string } } }>;
+  };
+};
+
 export type ConsoleGetKubeConfigQueryVariables = Exact<{
   name: Scalars['String']['input'];
 }>;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the cluster status issue by implementing a new GraphQL query to list cluster statuses and updating the cluster status retrieval logic. Enhance the cluster status provider to refresh data when the network connection is restored.

New Features:
- Introduce a new GraphQL query to list cluster statuses, including the last online time and metadata name.

Bug Fixes:
- Fix the cluster status issue by updating the cluster status retrieval logic to use the new listClusterStatus query.

Enhancements:
- Add an event listener to refresh cluster status when the network connection is restored.

<!-- Generated by sourcery-ai[bot]: end summary -->