### PR TITLE
kl cli update for listing of clusters

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -4482,8 +4482,8 @@ query consoleGetRegistryImage($image: String!) {
   }
 }
 
-query consoleGetRegistryImageUrl($image: String!, $meta: Map!) {
-  core_getRegistryImageURL(image: $image, meta: $meta) {
+query consoleGetRegistryImageUrl {
+  core_getRegistryImageURL {
     scriptUrl
     url
   }
@@ -6482,6 +6482,22 @@ query authCli_getRemoteLogin($loginId: String!, $secret: String!) {
   }
 }
 
+query authCli_listAccountClusters($pagination: CursorPaginationIn) {
+  infra_listBYOKClusters(pagination: $pagination) {
+    edges {
+      node {
+        clusterToken
+        displayName
+        id
+        metadata {
+          name
+          labels
+        }
+      }
+    }
+  }
+}
+
 mutation authCli_createClusterReference($cluster: BYOKClusterIn!) {
   infra_createBYOKCluster(cluster: $cluster) {
     id
@@ -6621,25 +6637,6 @@ query authCli_listImportedManagedResources($envName: String!, $search: SearchImp
       hasNextPage
       hasPrevPage
       startCursor
-    }
-    totalCount
-  }
-}
-
-query authCli_listByokClusters($search: SearchCluster, $pagination: CursorPaginationIn) {
-  infra_listBYOKClusters(search: $search, pagination: $pagination) {
-    edges {
-      cursor
-      node {
-        clusterToken
-        displayName
-        id
-        metadata {
-          name
-          namespace
-        }
-        updateTime
-      }
     }
     totalCount
   }

--- a/src/apps/auth/server/gql/cli-queries.ts
+++ b/src/apps/auth/server/gql/cli-queries.ts
@@ -717,6 +717,29 @@ export const cliQueries = (executor: IExecutor) => ({
       vars: (_: any) => {},
     }
   ),
+  cli_listAccountClusters: executor(
+    gql`
+      query Infra_listBYOKClusters($pagination: CursorPaginationIn) {
+        infra_listBYOKClusters(pagination: $pagination) {
+          edges {
+            node {
+              clusterToken
+              displayName
+              id
+              metadata {
+                name
+                labels
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      transformer: (data: any) => data.infra_listBYOKClusters,
+      vars(_: any) {},
+    }
+  ),
   cli_createClusterReference: executor(
     gql`
       mutation Infra_createBYOKCluster($cluster: BYOKClusterIn!) {
@@ -902,37 +925,6 @@ export const cliQueries = (executor: IExecutor) => ({
     `,
     {
       transformer: (data: any) => data.core_listImportedManagedResources,
-      vars(_: any) {},
-    }
-  ),
-  cli_listByokClusters: executor(
-    gql`
-      query Infra_listBYOKClusters(
-        $search: SearchCluster
-        $pagination: CursorPaginationIn
-      ) {
-        infra_listBYOKClusters(search: $search, pagination: $pagination) {
-          edges {
-            cursor
-            node {
-              clusterToken
-              displayName
-              id
-              metadata {
-                name
-                namespace
-              }
-              updateTime
-            }
-          }
-          totalCount
-        }
-      }
-    `,
-    {
-      transformer: (data: any) => {
-        return data.infra_listBYOKClusters;
-      },
       vars(_: any) {},
     }
   ),

--- a/src/apps/console/routes/_main+/$account+/settings+/images/handle-image-discovery.tsx
+++ b/src/apps/console/routes/_main+/$account+/settings+/images/handle-image-discovery.tsx
@@ -21,10 +21,7 @@ export const RegistryImageInstruction = ({
   const { data, isLoading, error } = useCustomSwr(
     'registry-image-instructions',
     async () => {
-      return api.getRegistryImageUrl({
-        image: '<image_name:image_tag>',
-        meta: {},
-      });
+      return api.getRegistryImageUrl();
     }
   );
 

--- a/src/apps/console/server/gql/queries/registry-image-queries.ts
+++ b/src/apps/console/server/gql/queries/registry-image-queries.ts
@@ -29,7 +29,7 @@ export const registryImagesQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleDeleteRegistryImageMutation) =>
         data.core_deleteRegistryImage,
-      vars(_: ConsoleDeleteRegistryImageMutationVariables) { },
+      vars(_: ConsoleDeleteRegistryImageMutationVariables) {},
     }
   ),
   getRegistryImage: executor(
@@ -51,13 +51,13 @@ export const registryImagesQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleGetRegistryImageQuery) =>
         data.core_getRegistryImage,
-      vars(_: ConsoleGetRegistryImageQueryVariables) { },
+      vars(_: ConsoleGetRegistryImageQueryVariables) {},
     }
   ),
   getRegistryImageUrl: executor(
     gql`
-      query Core_getRegistryImageURL($image: String!, $meta: Map!) {
-        core_getRegistryImageURL(image: $image, meta: $meta) {
+      query Core_getRegistryImageURL {
+        core_getRegistryImageURL {
           scriptUrl
           url
         }
@@ -66,7 +66,7 @@ export const registryImagesQueries = (executor: IExecutor) => ({
     {
       transformer: (data: ConsoleGetRegistryImageUrlQuery) =>
         data.core_getRegistryImageURL,
-      vars(_: ConsoleGetRegistryImageUrlQueryVariables) { },
+      vars(_: ConsoleGetRegistryImageUrlQueryVariables) {},
     }
   ),
   listRegistryImages: executor(
@@ -101,7 +101,7 @@ export const registryImagesQueries = (executor: IExecutor) => ({
       transformer: (data: ConsoleListRegistryImagesQuery) => {
         return data.core_listRegistryImages;
       },
-      vars(_: ConsoleListRegistryImagesQueryVariables) { },
+      vars(_: ConsoleListRegistryImagesQueryVariables) {},
     }
   ),
 });

--- a/src/generated/codegen-sdl.yml
+++ b/src/generated/codegen-sdl.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "http://gateway.kloudlite.svc.cluster.local:3000"
+schema: "http://gateway-api.kloudlite.svc.cluster.local:3000"
 generates:
   gql/sdl.graphql:
     plugins:

--- a/src/generated/codegen.yml
+++ b/src/generated/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "http://gateway.kloudlite.svc.cluster.local:3000"
+schema: "http://gateway-api.kloudlite.svc.cluster.local:3000"
 generates:
   gql/server.ts:
     documents:

--- a/src/generated/gql/sdl.graphql
+++ b/src/generated/gql/sdl.graphql
@@ -1,3 +1,8 @@
+"""
+Indicates exactly one field must be supplied and this field must not be `null`.
+"""
+directive @oneOf on INPUT_OBJECT
+
 """Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
   """The URL that specifies the behavior of this scalar."""
@@ -3951,7 +3956,7 @@ type Query {
   core_getManagedResouceOutputKeyValues(envName: String, keyrefs: [ManagedResourceKeyRefIn], msvcName: String): [ManagedResourceKeyValueRef!]!
   core_getManagedResource(envName: String, msvcName: String, name: String!): ManagedResource
   core_getRegistryImage(image: String!): RegistryImage
-  core_getRegistryImageURL(image: String!, meta: Map!): RegistryImageURL!
+  core_getRegistryImageURL: RegistryImageURL!
   core_getRouter(envName: String!, name: String!): Router
   core_getSecret(envName: String!, name: String!): Secret
   core_getSecretValues(envName: String!, queries: [SecretKeyRefIn!]): [SecretKeyValueRef!]

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -6114,8 +6114,7 @@ export type ConsoleGetRegistryImageQuery = {
 };
 
 export type ConsoleGetRegistryImageUrlQueryVariables = Exact<{
-  image: Scalars['String']['input'];
-  meta: Scalars['Map']['input'];
+  [key: string]: never;
 }>;
 
 export type ConsoleGetRegistryImageUrlQuery = {
@@ -8133,6 +8132,23 @@ export type AuthCli_GetRemoteLoginQuery = {
   auth_getRemoteLogin?: { authHeader?: string; status: string };
 };
 
+export type AuthCli_ListAccountClustersQueryVariables = Exact<{
+  pagination?: InputMaybe<CursorPaginationIn>;
+}>;
+
+export type AuthCli_ListAccountClustersQuery = {
+  infra_listBYOKClusters?: {
+    edges: Array<{
+      node: {
+        clusterToken: string;
+        displayName: string;
+        id: string;
+        metadata: { name: string; labels?: any };
+      };
+    }>;
+  };
+};
+
 export type AuthCli_CreateClusterReferenceMutationVariables = Exact<{
   cluster: ByokClusterIn;
 }>;
@@ -8273,27 +8289,6 @@ export type AuthCli_ListImportedManagedResourcesQuery = {
       hasPrevPage?: boolean;
       startCursor?: string;
     };
-  };
-};
-
-export type AuthCli_ListByokClustersQueryVariables = Exact<{
-  search?: InputMaybe<SearchCluster>;
-  pagination?: InputMaybe<CursorPaginationIn>;
-}>;
-
-export type AuthCli_ListByokClustersQuery = {
-  infra_listBYOKClusters?: {
-    totalCount: number;
-    edges: Array<{
-      cursor: string;
-      node: {
-        clusterToken: string;
-        displayName: string;
-        id: string;
-        updateTime: any;
-        metadata: { name: string; namespace?: string };
-      };
-    }>;
   };
 };
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update CLI to include a new query for listing account clusters and simplify existing queries by removing redundant parameters.

New Features:
- Introduce a new GraphQL query `cli_listAccountClusters` to list account clusters with pagination support.

Enhancements:
- Simplify the `getRegistryImageUrl` query by removing unnecessary parameters.

<!-- Generated by sourcery-ai[bot]: end summary -->