### PR TITLE
intercept app cli query updated

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -6100,6 +6100,10 @@ mutation authCli_createGlobalVPNDevice($gvpnDevice: GlobalVPNDeviceIn!) {
   }
 }
 
+query authCli_getDNSHostSuffix {
+  core_getDNSHostSuffix
+}
+
 query authCli_getMresOutputKeyValues($msvcName: String!, $keyrefs: [ManagedResourceKeyRefIn]) {
   core_getManagedResouceOutputKeyValues(msvcName: $msvcName, keyrefs: $keyrefs) {
     key
@@ -6219,11 +6223,12 @@ mutation authCli_intercepExternalApp($envName: String!, $appName: String!, $devi
   )
 }
 
-mutation authCli_interceptApp($portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!], $intercept: Boolean!, $deviceName: String!, $appName: String!, $envName: String!) {
-  core_interceptApp(
+mutation authCli_interceptApp($portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!], $intercept: Boolean!, $clusterName: String!, $ipAddr: String!, $appName: String!, $envName: String!) {
+  core_interceptAppOnLocalCluster(
     portMappings: $portMappings
     intercept: $intercept
-    deviceName: $deviceName
+    clusterName: $clusterName
+    ipAddr: $ipAddr
     appname: $appName
     envName: $envName
   )

--- a/src/apps/auth/server/gql/cli-queries.ts
+++ b/src/apps/auth/server/gql/cli-queries.ts
@@ -53,6 +53,20 @@ export const cliQueries = (executor: IExecutor) => ({
     }
   ),
 
+  cli_getDNSHostSuffix: executor(
+    gql`
+      query Core_getDNSHostSuffix {
+        core_getDNSHostSuffix
+      }
+    `,
+    {
+      transformer(data: any) {
+        return data.core_getDNSHostSuffix;
+      },
+      vars(_: any) {},
+    }
+  ),
+
   cli_getMresOutputKeyValues: executor(
     gql`
       query Core_getManagedResouceOutputKeyValues(
@@ -293,24 +307,26 @@ export const cliQueries = (executor: IExecutor) => ({
   ),
   cli_interceptApp: executor(
     gql`
-      mutation Core_interceptApp(
+      mutation Core_interceptAppOnLocalCluster(
         $portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]
         $intercept: Boolean!
-        $deviceName: String!
+        $clusterName: String!
+        $ipAddr: String!
         $appName: String!
         $envName: String!
       ) {
-        core_interceptApp(
+        core_interceptAppOnLocalCluster(
           portMappings: $portMappings
           intercept: $intercept
-          deviceName: $deviceName
+          clusterName: $clusterName
+          ipAddr: $ipAddr
           appname: $appName
           envName: $envName
         )
       }
     `,
     {
-      transformer: (data: any) => data.core_interceptApp,
+      transformer: (data: any) => data.core_interceptAppOnLocalCluster,
       vars: (_: any) => {},
     }
   ),

--- a/src/generated/gql/sdl.graphql
+++ b/src/generated/gql/sdl.graphql
@@ -3624,6 +3624,7 @@ type Mutation {
   core_deleteSecret(envName: String!, secretName: String!): Boolean!
   core_importManagedResource(envName: String!, importName: String!, mresName: String!, msvcName: String!): ImportedManagedResource
   core_interceptApp(appname: String!, deviceName: String!, envName: String!, intercept: Boolean!, portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]): Boolean!
+  core_interceptAppOnLocalCluster(appname: String!, clusterName: String!, envName: String!, intercept: Boolean!, ipAddr: String!, portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]): Boolean!
   core_interceptExternalApp(deviceName: String!, envName: String!, externalAppName: String!, intercept: Boolean!, portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]): Boolean!
   core_removeDeviceIntercepts(deviceName: String!, envName: String!): Boolean!
   core_updateApp(app: AppIn!, envName: String!): App

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -7752,6 +7752,12 @@ export type AuthCli_CreateGlobalVpnDeviceMutation = {
   };
 };
 
+export type AuthCli_GetDnsHostSuffixQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type AuthCli_GetDnsHostSuffixQuery = { core_getDNSHostSuffix: string };
+
 export type AuthCli_GetMresOutputKeyValuesQueryVariables = Exact<{
   msvcName: Scalars['String']['input'];
   keyrefs?: InputMaybe<
@@ -7901,12 +7907,15 @@ export type AuthCli_InterceptAppMutationVariables = Exact<{
     | Github__Com___Kloudlite___Operator___Apis___Crds___V1__AppInterceptPortMappingsIn
   >;
   intercept: Scalars['Boolean']['input'];
-  deviceName: Scalars['String']['input'];
+  clusterName: Scalars['String']['input'];
+  ipAddr: Scalars['String']['input'];
   appName: Scalars['String']['input'];
   envName: Scalars['String']['input'];
 }>;
 
-export type AuthCli_InterceptAppMutation = { core_interceptApp: boolean };
+export type AuthCli_InterceptAppMutation = {
+  core_interceptAppOnLocalCluster: boolean;
+};
 
 export type AuthCli_RemoveDeviceInterceptsMutationVariables = Exact<{
   envName: Scalars['String']['input'];


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new GraphQL query to fetch DNS host suffix and enhance the existing app interception mutation by renaming it and modifying its parameters to support local cluster interception.

New Features:
- Add a new GraphQL query `cli_getDNSHostSuffix` to retrieve the DNS host suffix.

Enhancements:
- Update the `cli_interceptApp` mutation to `cli_interceptAppOnLocalCluster`, changing parameters from `deviceName` to `clusterName` and adding `ipAddr`.

<!-- Generated by sourcery-ai[bot]: end summary -->