### PR TITLE
WEB: Discard changes working fine when switching tab of app settings

### DIFF
--- a/lib/client/hooks/use-unsaved-changes.tsx
+++ b/lib/client/hooks/use-unsaved-changes.tsx
@@ -13,8 +13,8 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { ChildrenProps } from '~/components/types';
 import Popup from '~/components/molecule/popup';
+import { ChildrenProps } from '~/components/types';
 import { useReload } from '../helpers/reloader';
 
 const UnsavedChanges = createContext<{
@@ -28,6 +28,7 @@ const UnsavedChanges = createContext<{
   performAction: string;
   setPerformAction: (action: string) => void;
   loading: boolean;
+  onProceed?: () => void;
 }>({
   hasChanges: false,
   setHasChanges() {},
@@ -39,6 +40,7 @@ const UnsavedChanges = createContext<{
   performAction: '',
   setPerformAction() {},
   loading: false,
+  onProceed() {},
 });
 
 export const UnsavedChangesProvider = ({ children }: ChildrenProps) => {
@@ -49,6 +51,7 @@ export const UnsavedChangesProvider = ({ children }: ChildrenProps) => {
   const location = useLocation();
   const { state, proceed, reset } = unstable_useBlocker(({ nextLocation }) => {
     if (hasChanges && !ignorePaths.includes(nextLocation.pathname)) {
+      console.log('hasChanges', hasChanges);
       return true;
     }
     return false;
@@ -146,6 +149,8 @@ export const UnsavedChangesProvider = ({ children }: ChildrenProps) => {
     </UnsavedChanges.Provider>
   );
 };
+
 export const useUnsavedChanges = () => {
+  // const
   return useContext(UnsavedChanges);
 };

--- a/lib/client/hooks/use-unsaved-changes.tsx
+++ b/lib/client/hooks/use-unsaved-changes.tsx
@@ -68,8 +68,8 @@ export const UnsavedChangesProvider = ({
         }
         return hasChanges;
       },
-      [hasChanges],
-    ),
+      [hasChanges]
+    )
   );
 
   useEffect(() => {
@@ -122,7 +122,7 @@ export const UnsavedChangesProvider = ({
           performAction,
           setPerformAction,
           s,
-        ],
+        ]
       )}
     >
       {children}
@@ -163,6 +163,5 @@ export const DISCARD_ACTIONS = {
 };
 
 export const useUnsavedChanges = () => {
-  // const
   return useContext(UnsavedChanges);
 };

--- a/src/apps/console/hooks/use-is-owner.tsx
+++ b/src/apps/console/hooks/use-is-owner.tsx
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import useCustomSwr from '~/root/lib/client/hooks/use-custom-swr';
+import { useConsoleApi } from '../server/gql/api-provider';
+
+export const useIsOwner = ({ accountName }: { accountName: string }) => {
+  const api = useConsoleApi();
+  const { data: teamMembers, isLoading: teamMembersLoading } = useCustomSwr(
+    `${accountName}-owners`,
+    async () => {
+      return api.listMembershipsForAccount({
+        accountName,
+      });
+    }
+  );
+
+  const { data: currentUser, isLoading: currentUserLoading } = useCustomSwr(
+    'current-user',
+    async () => {
+      return api.whoAmI();
+    }
+  );
+
+  const isOwner = useCallback(() => {
+    if (!teamMembers || !currentUser) return false;
+
+    const owner = teamMembers.find((member) => member.role === 'account_owner');
+
+    return owner?.user?.email === currentUser?.email;
+  }, [teamMembers, currentUser]);
+
+  return {
+    isOwner: isOwner(),
+    isLoading: teamMembersLoading || currentUserLoading,
+  };
+};

--- a/src/apps/console/page-components/app/compute.tsx
+++ b/src/apps/console/page-components/app/compute.tsx
@@ -7,7 +7,10 @@ import ExtendedFilledTab from '~/console/components/extended-filled-tab';
 import { useAppState } from '~/console/page-components/app-states';
 import { FadeIn, parseValue } from '~/console/page-components/util';
 import useForm, { dummyEvent } from '~/root/lib/client/hooks/use-form';
-import { useUnsavedChanges } from '~/root/lib/client/hooks/use-unsaved-changes';
+import {
+  DISCARD_ACTIONS,
+  useUnsavedChanges,
+} from '~/root/lib/client/hooks/use-unsaved-changes';
 import Yup from '~/root/lib/server/helpers/yup';
 import appInitialFormValues, { mapFormValuesToApp } from './app-utils';
 import { plans } from './datas';
@@ -79,7 +82,7 @@ const AppCompute = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
           mapFormValuesToApp({
             appIn: val,
             oldAppIn: s,
-          })
+          }),
         );
       },
     });
@@ -97,7 +100,7 @@ const AppCompute = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
   }, [values, mode]);
 
   useEffect(() => {
-    if (performAction === 'discard-changes') {
+    if (performAction === DISCARD_ACTIONS.DISCARD_CHANGES) {
       resetValues();
     }
   }, [performAction]);
@@ -167,7 +170,7 @@ const AppCompute = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
                 handleChange('selectedPlan')(dummyEvent(v.value));
                 handleChange('memPerCpu')(dummyEvent(v.memoryPerCpu));
                 handleChange('cpuMode')(
-                  dummyEvent(v.isShared ? 'shared' : 'dedicated')
+                  dummyEvent(v.isShared ? 'shared' : 'dedicated'),
                 );
               }}
             />

--- a/src/apps/console/page-components/app/general.tsx
+++ b/src/apps/console/page-components/app/general.tsx
@@ -16,7 +16,10 @@ import { ensureAccountClientSide } from '~/console/server/utils/auth-utils';
 import { constants } from '~/console/server/utils/constants';
 import useDebounce from '~/root/lib/client/hooks/use-debounce';
 import useForm, { dummyEvent } from '~/root/lib/client/hooks/use-form';
-import { useUnsavedChanges } from '~/root/lib/client/hooks/use-unsaved-changes';
+import {
+  DISCARD_ACTIONS,
+  useUnsavedChanges,
+} from '~/root/lib/client/hooks/use-unsaved-changes';
 import Yup from '~/root/lib/server/helpers/yup';
 import { handleError } from '~/root/lib/utils/common';
 
@@ -119,7 +122,7 @@ const AppGeneral = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
         setImageLoaded(false);
       }
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -133,7 +136,7 @@ const AppGeneral = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
       }
     },
     300,
-    [imageSearchText]
+    [imageSearchText],
   );
 
   const {
@@ -176,7 +179,7 @@ const AppGeneral = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
       displayName: Yup.string().required(),
       imageUrl: Yup.string().matches(
         constants.dockerImageFormatRegex,
-        'Invalid image format'
+        'Invalid image format',
       ),
       manualRepo: Yup.string().when(
         ['imageUrl', 'imageMode'],
@@ -189,7 +192,7 @@ const AppGeneral = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
             return schema.required().matches(regex, 'Invalid image format');
           }
           return schema;
-        }
+        },
       ),
       imageMode: Yup.string().required(),
       source: Yup.object()
@@ -242,7 +245,7 @@ const AppGeneral = ({ mode = 'new' }: { mode: 'edit' | 'new' }) => {
   }, [values, mode]);
 
   useEffect(() => {
-    if (performAction === 'discard-changes') {
+    if (performAction === DISCARD_ACTIONS.DISCARD_CHANGES) {
       // if (app.ciBuildId) {
       //   setIsEdited(false);
       // }

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/app+/$app+/settings+/_layout.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/app+/$app+/settings+/_layout.tsx
@@ -18,6 +18,7 @@ import { constants } from '~/console/server/utils/constants';
 import { useReload } from '~/lib/client/helpers/reloader';
 import useForm from '~/lib/client/hooks/use-form';
 import {
+  DISCARD_ACTIONS,
   UnsavedChangesProvider,
   useUnsavedChanges,
 } from '~/lib/client/hooks/use-unsaved-changes';
@@ -69,8 +70,8 @@ const Layout = () => {
     setIgnorePaths(
       navItems.map(
         (ni) =>
-          `/${account}/env/${environment}/app/${appName}/settings/${ni.value}`
-      )
+          `/${account}/env/${environment}/app/${appName}/settings/${ni.value}`,
+      ),
     );
   }, []);
 
@@ -143,11 +144,11 @@ const Layout = () => {
                                 if (app.ciBuildId) {
                                   if (
                                     readOnlyApp.spec.containers?.[0].image.includes(
-                                      constants.defaultAppRepoNameOnly
+                                      constants.defaultAppRepoNameOnly,
                                     )
                                   ) {
                                     return `${constants.defaultAppRepoName(
-                                      accountName
+                                      accountName,
                                     )}:${tagName}`;
                                   }
                                   return `${registryHost}/${accountName}/${
@@ -158,7 +159,7 @@ const Layout = () => {
                                   }`;
                                 }
                                 return `${constants.defaultAppRepoName(
-                                  accountName
+                                  accountName,
                                 )}:${tagName}`;
                               })(),
                               name: 'container-0',
@@ -177,7 +178,7 @@ const Layout = () => {
         }
         toast.success('App updated successfully');
         // @ts-ignore
-        setPerformAction('init');
+        setPerformAction(DISCARD_ACTIONS.INIT);
         if (!gitMode) {
           // @ts-ignore
           setBuildData(null);
@@ -221,7 +222,7 @@ const Layout = () => {
   }, [rootContext.app]);
 
   useEffect(() => {
-    if (performAction === 'discard-changes') {
+    if (performAction === DISCARD_ACTIONS.DISCARD_CHANGES) {
       setApp(rootContext.app);
       setReadOnlyApp(rootContext.app);
       // @ts-ignore
@@ -237,7 +238,7 @@ const Layout = () => {
           'min-w-[1000px]': showDiff,
           'min-w-[500px]': !showDiff,
         })}
-        show={performAction === 'view-changes'}
+        show={performAction === DISCARD_ACTIONS.VIEW_CHANGES}
         onOpenChange={(v) => setPerformAction(v)}
       >
         <Popup.Header>Commit Changes</Popup.Header>
@@ -302,7 +303,11 @@ const Settings = () => {
   const rootContext = useOutletContext<IAppContext>();
   return (
     <AppContextProvider initialAppState={rootContext.app}>
-      <UnsavedChangesProvider>
+      <UnsavedChangesProvider
+        onProceed={({ setPerformAction }) => {
+          setPerformAction?.(DISCARD_ACTIONS.DISCARD_CHANGES);
+        }}
+      >
         <Layout />
       </UnsavedChangesProvider>
     </AppContextProvider>

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/app+/$app+/settings+/_layout.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/app+/$app+/settings+/_layout.tsx
@@ -70,8 +70,8 @@ const Layout = () => {
     setIgnorePaths(
       navItems.map(
         (ni) =>
-          `/${account}/env/${environment}/app/${appName}/settings/${ni.value}`,
-      ),
+          `/${account}/env/${environment}/app/${appName}/settings/${ni.value}`
+      )
     );
   }, []);
 
@@ -144,11 +144,11 @@ const Layout = () => {
                                 if (app.ciBuildId) {
                                   if (
                                     readOnlyApp.spec.containers?.[0].image.includes(
-                                      constants.defaultAppRepoNameOnly,
+                                      constants.defaultAppRepoNameOnly
                                     )
                                   ) {
                                     return `${constants.defaultAppRepoName(
-                                      accountName,
+                                      accountName
                                     )}:${tagName}`;
                                   }
                                   return `${registryHost}/${accountName}/${
@@ -159,7 +159,7 @@ const Layout = () => {
                                   }`;
                                 }
                                 return `${constants.defaultAppRepoName(
-                                  accountName,
+                                  accountName
                                 )}:${tagName}`;
                               })(),
                               name: 'container-0',

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
@@ -21,7 +21,10 @@ import NoResultsFound from '~/console/components/no-results-found';
 import { IShowDialog } from '~/console/components/types.d';
 import { useAppState } from '~/console/page-components/app-states';
 import useForm from '~/root/lib/client/hooks/use-form';
-import { useUnsavedChanges } from '~/root/lib/client/hooks/use-unsaved-changes';
+import {
+  DISCARD_ACTIONS,
+  useUnsavedChanges,
+} from '~/root/lib/client/hooks/use-unsaved-changes';
 import Yup from '~/root/lib/server/helpers/yup';
 import { NonNullableString } from '~/root/lib/types/common';
 import AppDialog from './app-dialogs';
@@ -343,8 +346,7 @@ export const EnvironmentVariables = () => {
   });
 
   useEffect(() => {
-    if (performAction === 'discard-changes') {
-      console.log('discard-changes');
+    if (performAction === DISCARD_ACTIONS.DISCARD_CHANGES) {
       // if (app.ciBuildId) {
       //   setIsEdited(false);
       // }

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
@@ -243,9 +243,10 @@ export const EnvironmentVariables = () => {
     submit,
     resetValues: reset,
   } = useForm({
-    initialValues: getReadOnlyContainer().env || [],
+    initialValues: getReadOnlyContainer().env || null,
     validationSchema: Yup.array(entry),
     onSubmit: (val) => {
+      //@ts-ignore
       setContainer((c) => ({
         ...c,
         env: val,

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
@@ -273,6 +273,7 @@ export const EnvironmentVariables = () => {
   };
 
   const removeEntry = (val: IEnvVariable) => {
+    // @ts-ignore
     setValues((v) => {
       const nv = v?.filter((v) => v.key !== val.key);
       return nv;

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/new-app/app-environment-variables.tsx
@@ -246,7 +246,7 @@ export const EnvironmentVariables = () => {
     initialValues: getReadOnlyContainer().env || null,
     validationSchema: Yup.array(entry),
     onSubmit: (val) => {
-      //@ts-ignore
+      // @ts-ignore
       setContainer((c) => ({
         ...c,
         env: val,

--- a/src/apps/iot-console/routes/_main+/$account+/$project+/deviceblueprint+/$deviceblueprint+/app+/$app+/settings+/_layout.tsx
+++ b/src/apps/iot-console/routes/_main+/$account+/$project+/deviceblueprint+/$deviceblueprint+/app+/$app+/settings+/_layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useOutletContext } from '@remix-run/react';
 import SidebarLayout from '~/iotconsole/components/sidebar-layout';
 import {
+  DISCARD_ACTIONS,
   UnsavedChangesProvider,
   useUnsavedChanges,
 } from '~/lib/client/hooks/use-unsaved-changes';
@@ -52,8 +53,8 @@ const Layout = () => {
     setIgnorePaths(
       navItems.map(
         (ni) =>
-          `/${account}/deviceblueprint/${deviceBlueprintName}/app/${appName}/settings/${ni.value}`
-      )
+          `/${account}/deviceblueprint/${deviceBlueprintName}/app/${appName}/settings/${ni.value}`,
+      ),
     );
   }, []);
 
@@ -110,7 +111,7 @@ const Layout = () => {
   }, [rootContext.app]);
 
   useEffect(() => {
-    if (performAction === 'discard-changes') {
+    if (performAction === DISCARD_ACTIONS.DISCARD_CHANGES) {
       setApp(rootContext.app);
       setPerformAction('');
     }
@@ -120,7 +121,7 @@ const Layout = () => {
     <SidebarLayout navItems={navItems} parentPath="/settings">
       <Popup.Root
         className="w-[90vw] max-w-[1440px] min-w-[1000px]"
-        show={performAction === 'view-changes'}
+        show={performAction === DISCARD_ACTIONS.VIEW_CHANGES}
         onOpenChange={(v) => setPerformAction(v)}
       >
         <Popup.Header>Review Changes</Popup.Header>

--- a/src/design-system/components/atoms/tabs.tsx
+++ b/src/design-system/components/atoms/tabs.tsx
@@ -95,7 +95,7 @@ const TabBase = ({
           'rounded-lg hover:bg-surface-basic-hovered active:bg-surface-basic-pressed':
             variant === 'filled',
           // 'border border-transparent': variant === 'filled' && !active,
-        },
+        }
       )}
     >
       <RovingFocusGroup.Item
@@ -126,7 +126,7 @@ const TabBase = ({
               ...(fitted && {
                 'py-md': variant !== 'filled',
               }),
-            },
+            }
           )}
         >
           {variant === 'plain' && <div className="h-md bg-none w-full z-0" />}
@@ -139,7 +139,7 @@ const TabBase = ({
             <motion.div
               layoutId="underline"
               className={cn(
-                'h-md z-10 absolute left-0 bottom-0 w-full bg-border-primary',
+                'h-md z-10 absolute left-0 bottom-0 w-full bg-border-primary'
               )}
             />
           )}
@@ -183,7 +183,7 @@ const Root = forwardRef<HTMLDivElement, ITabs<any>>(
       children,
       toLabel,
     },
-    ref,
+    ref
   ) => {
     const id = useId();
     // id = useMemo(() => id, [children, value, basePath, size, variant]);
@@ -198,7 +198,7 @@ const Root = forwardRef<HTMLDivElement, ITabs<any>>(
             'md:gap-4xl': size === 'md' && variant !== 'filled',
             'gap-lg': size === 'sm' || variant === 'filled',
           },
-          className,
+          className
         )}
         ref={ref}
         asChild
@@ -239,7 +239,7 @@ const Root = forwardRef<HTMLDivElement, ITabs<any>>(
         </motion.div>
       </RovingFocusGroup.Root>
     );
-  },
+  }
 );
 
 const Tabs = {


### PR DESCRIPTION
## Summary by Sourcery

Implement a new hook to check account ownership and enhance the unsaved changes handling by introducing a callback mechanism and a standardized action management system.

New Features:
- Introduce a new hook `useIsOwner` to determine if the current user is the owner of an account by checking their role against the account's team members.

Enhancements:
- Enhance the `UnsavedChangesProvider` to accept an `onProceed` callback, allowing actions to be performed when changes are discarded.
- Refactor the handling of unsaved changes by introducing a `DISCARD_ACTIONS` object to manage different discard actions consistently across components.