### PR TITLE
intercept app cli api updated

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -4699,12 +4699,11 @@ mutation authCli_intercepExternalApp($envName: String!, $appName: String!, $devi
   )
 }
 
-mutation authCli_interceptApp($portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!], $intercept: Boolean!, $clusterName: String!, $ipAddr: String!, $appName: String!, $envName: String!) {
-  core_interceptAppOnLocalCluster(
+mutation authCli_interceptApp($portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!], $intercept: Boolean!, $deviceName: String!, $appName: String!, $envName: String!) {
+  core_interceptApp(
     portMappings: $portMappings
     intercept: $intercept
-    clusterName: $clusterName
-    ipAddr: $ipAddr
+    deviceName: $deviceName
     appname: $appName
     envName: $envName
   )
@@ -4980,6 +4979,7 @@ query authCli_listAccountClusters($pagination: CursorPaginationIn) {
       node {
         clusterToken
         displayName
+        lastOnlineAt
         id
         metadata {
           name

--- a/src/apps/auth/server/gql/cli-queries.ts
+++ b/src/apps/auth/server/gql/cli-queries.ts
@@ -305,28 +305,51 @@ export const cliQueries = (executor: IExecutor) => ({
       vars: (_: any) => {},
     }
   ),
+  // cli_interceptApp: executor(
+  //   gql`
+  //     mutation Core_interceptAppOnLocalCluster(
+  //       $portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]
+  //       $intercept: Boolean!
+  //       $clusterName: String!
+  //       $ipAddr: String!
+  //       $appName: String!
+  //       $envName: String!
+  //     ) {
+  //       core_interceptAppOnLocalCluster(
+  //         portMappings: $portMappings
+  //         intercept: $intercept
+  //         clusterName: $clusterName
+  //         ipAddr: $ipAddr
+  //         appname: $appName
+  //         envName: $envName
+  //       )
+  //     }
+  //   `,
+  //   {
+  //     transformer: (data: any) => data.core_interceptAppOnLocalCluster,
+  //     vars: (_: any) => {},
+  //   }
+  // ),
   cli_interceptApp: executor(
     gql`
-      mutation Core_interceptAppOnLocalCluster(
+      mutation Core_interceptApp(
         $portMappings: [Github__com___kloudlite___operator___apis___crds___v1__AppInterceptPortMappingsIn!]
         $intercept: Boolean!
-        $clusterName: String!
-        $ipAddr: String!
+        $deviceName: String!
         $appName: String!
         $envName: String!
       ) {
-        core_interceptAppOnLocalCluster(
+        core_interceptApp(
           portMappings: $portMappings
           intercept: $intercept
-          clusterName: $clusterName
-          ipAddr: $ipAddr
+          deviceName: $deviceName
           appname: $appName
           envName: $envName
         )
       }
     `,
     {
-      transformer: (data: any) => data.core_interceptAppOnLocalCluster,
+      transformer: (data: any) => data.core_interceptApp,
       vars: (_: any) => {},
     }
   ),
@@ -741,6 +764,7 @@ export const cliQueries = (executor: IExecutor) => ({
             node {
               clusterToken
               displayName
+              lastOnlineAt
               id
               metadata {
                 name

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -6307,15 +6307,12 @@ export type AuthCli_InterceptAppMutationVariables = Exact<{
     | Github__Com___Kloudlite___Operator___Apis___Crds___V1__AppInterceptPortMappingsIn
   >;
   intercept: Scalars['Boolean']['input'];
-  clusterName: Scalars['String']['input'];
-  ipAddr: Scalars['String']['input'];
+  deviceName: Scalars['String']['input'];
   appName: Scalars['String']['input'];
   envName: Scalars['String']['input'];
 }>;
 
-export type AuthCli_InterceptAppMutation = {
-  core_interceptAppOnLocalCluster: boolean;
-};
+export type AuthCli_InterceptAppMutation = { core_interceptApp: boolean };
 
 export type AuthCli_RemoveDeviceInterceptsMutationVariables = Exact<{
   envName: Scalars['String']['input'];
@@ -6577,6 +6574,7 @@ export type AuthCli_ListAccountClustersQuery = {
       node: {
         clusterToken: string;
         displayName: string;
+        lastOnlineAt?: any;
         id: string;
         metadata: { name: string; labels?: any };
       };


### PR DESCRIPTION
## Summary by Sourcery

Update the GraphQL API for app interception by modifying the mutation parameters to use 'deviceName' instead of 'clusterName' and 'ipAddr'. Enhance the account clusters query to include the 'lastOnlineAt' field.

Enhancements:
- Update the GraphQL mutation for intercepting apps by replacing 'clusterName' and 'ipAddr' with 'deviceName' in the parameters.
- Add 'lastOnlineAt' field to the 'authCli_listAccountClusters' query to include the last online timestamp of clusters.