### PR TITLE
Servicebinding

### DIFF
--- a/gql-queries-generator/doc/queries.graphql
+++ b/gql-queries-generator/doc/queries.graphql
@@ -4580,6 +4580,7 @@ query consoleListServiceBinding($envName: String!, $pagination: CursorPagination
           }
         }
         updateTime
+        serviceHost
       }
     }
   }

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/services/services-resource-v2.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/services/services-resource-v2.tsx
@@ -29,13 +29,16 @@ import { useConsoleApi } from '~/console/server/gql/api-provider';
 import { IEnvironmentContext } from '../_layout';
 import { useReload } from '~/root/lib/client/helpers/reloader';
 import { toast } from '@kloudlite/design-system/molecule/toast';
+import { CopyContentToClipboard } from '~/console/components/common-console-components';
 
 const RESOURCE_NAME = 'managed resource';
 type BaseType = ExtractNodeType<IServiceBinding>;
 
 const parseItem = (item: BaseType) => {
+  console.log("svcbinding", item)
   return {
     name: item.spec?.serviceRef?.name || "",
+    serviceHost: item.serviceHost,
     updateInfo: {
       time: parseUpdateOrCreatedOn(item),
     },
@@ -142,6 +145,14 @@ const InterceptPortView = ({
   );
 };
 
+const ServiceView = ({ service }: { service: string }) => {
+  return (
+    <CopyContentToClipboard
+      content={service}
+      toastMessage="App service url copied successfully."
+    />
+  );
+};
 
 interface IResource {
   items: BaseType[];
@@ -191,6 +202,11 @@ const ListView = ({ items = [], onAction }: IResource) => {
             className: listClass.title,
           },
           {
+            render: () => 'Service Host',
+            name: 'serviceHost',
+            className: 'w-[300px] truncate',
+          },
+          {
             render: () => '',
             name: 'intercept',
             className: 'w-[250px] truncate',
@@ -212,11 +228,14 @@ const ListView = ({ items = [], onAction }: IResource) => {
           },
         ],
         rows: items.map((i) => {
-          const { name, updateInfo } = parseItem(i);
+          const { name, updateInfo, serviceHost } = parseItem(i);
           return {
             columns: {
               name: {
                 render: () => <ListTitleV2 title={name} />,
+              },
+              serviceHost: {
+                render: () => <ServiceView service={serviceHost || ""} />
               },
               intercept: {
                 render: () =>
@@ -229,7 +248,6 @@ const ListView = ({ items = [], onAction }: IResource) => {
                     </div>
                   ) : null,
               },
-
               updated: {
                 render: () => <ListItemV2 subtitle={updateInfo.time} />,
               },

--- a/src/apps/console/routes/_main+/$account+/env+/$environment+/workloads+/helm-chart+/$helmchart+/settings+/values/route.tsx
+++ b/src/apps/console/routes/_main+/$account+/env+/$environment+/workloads+/helm-chart+/$helmchart+/settings+/values/route.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef } from 'react';
 import { LoadingPlaceHolder } from '~/console/components/loading';
 import Yup from '~/root/lib/server/helpers/yup';
 import { DISCARD_ACTIONS, useUnsavedChanges } from '~/root/lib/client/hooks/use-unsaved-changes';
+import { parseName } from '~/console/server/r-utils/common';
 
 
 const SettingValues = () => {
@@ -130,15 +131,15 @@ const SettingValues = () => {
 
                   if (
                     values.activeTab === 'values' &&
-                    path === '/values.yaml'
+                    path === `/${parseName(readOnlyHelmChart)}-values.yaml`
                   ) {
                     handleChange('values')(dummyEvent(e));
                   }
                 }}
                 path={
                   values.activeTab === 'defaults'
-                    ? 'defaults.yaml'
-                    : 'values.yaml'
+                    ? `${parseName(readOnlyHelmChart)}-defaults.yaml`
+                    : `${parseName(readOnlyHelmChart)}-values.yaml`
                 }
                 onMount={(e) => {
                   editorRef.current = e;

--- a/src/apps/console/server/gql/queries/service-binding-queries.ts
+++ b/src/apps/console/server/gql/queries/service-binding-queries.ts
@@ -90,6 +90,7 @@ export const serviceBindingQueries = (executor: IExecutor) => ({
                 }
               }
               updateTime
+              serviceHost
             }
           }
         }

--- a/src/generated/gql/sdl.graphql
+++ b/src/generated/gql/sdl.graphql
@@ -4547,6 +4547,7 @@ type ServiceBinding {
   markedForDeletion: Boolean
   metadata: Metadata
   recordVersion: Int!
+  serviceHost: String
   spec: Github__com___kloudlite___operator___apis___networking___v1__ServiceBindingSpec
   status: Github__com___kloudlite___operator___pkg___operator__Status
   updateTime: Date!

--- a/src/generated/gql/server.ts
+++ b/src/generated/gql/server.ts
@@ -6286,6 +6286,7 @@ export type ConsoleListServiceBindingQuery = {
         markedForDeletion?: boolean;
         recordVersion: number;
         updateTime: any;
+        serviceHost?: string;
         interceptStatus?: {
           intercepted?: boolean;
           toAddr: string;


### PR DESCRIPTION
- added servicehost

## Summary by Sourcery

Add a 'Service Host' field to the service binding resource view and enhance the 'SettingValues' component to dynamically generate file paths based on Helm chart names.

New Features:
- Introduce a new 'Service Host' field in the service binding resource view, allowing users to view and copy the service host URL.

Enhancements:
- Update the path handling logic in the 'SettingValues' component to dynamically generate file paths based on the parsed name of the Helm chart.